### PR TITLE
Added missing Alert fields in AlertDetails view, closes #50, closes #51, closes #52, closes #53   

### DIFF
--- a/src/map/components/AlertDetails/components/AlertDetailItem/index.js
+++ b/src/map/components/AlertDetails/components/AlertDetailItem/index.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+function AlertDetailItem({ property, value }) {
+    const formatTitle = title => {
+        switch (title) {
+            case 'area.description': {
+                return ' AREA DESCRIPTION:';
+            }
+            case 'description': {
+                return ' ALERT DESCRIPTION:';
+            }
+            case 'reportedAt': {
+                return 'WHEN WAS REPORTED:';
+            }
+            case 'expectedAt': {
+                return 'WHEN IS EXPECTED:';
+            }
+
+            case 'expiredAt': {
+                return 'WHEN WILL EXPIRE:';
+            }
+
+            case 'source': {
+                return 'ISSUED BY:'
+            }
+
+            default:
+                return title;
+        }
+    };
+
+    const formatValue = (title, data) => {
+        switch (title) {
+            case 'reportedAt': {
+                const m = moment(data, 'YYYY-MM-DD');
+                return `${m.calendar()}`;
+            }
+            case 'expectedAt': {
+                const m = moment(data, 'YYYY-MM-DD');
+                return `${m.calendar()}`;
+            }
+
+            case 'expiredAt': {
+                const m = moment(data, 'YYYY-MM-DD');
+                return `${m.calendar()}`;
+            }
+
+            default:
+                return data;
+        }
+    };
+
+    return (
+        <div style={{ marginBottom: '20px' }}>
+            <div
+                style={{
+                    color: '#189ad1',
+                    display: 'table',
+                    textTransform: 'uppercase',
+                }}
+            >
+                {' '}
+                {formatTitle(property)}
+            </div>
+            <div
+                style={{
+                    fontWeight: 700,
+                    fontSize: '13px',
+                    color: '#8a8a8a',
+                }}
+            >
+                {' '}
+                {formatValue(property, value)}{' '}
+            </div>
+        </div>
+    );
+}
+
+AlertDetailItem.propTypes = {
+    property: PropTypes.string,
+    value: PropTypes.string,
+};
+
+AlertDetailItem.defaultProps = {
+    property: 'no data',
+    value: 'no data',
+};
+
+
+export default AlertDetailItem;

--- a/src/map/components/AlertDetails/index.js
+++ b/src/map/components/AlertDetails/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames/bind';
-import { Button } from 'antd';
+import { Icon, Tooltip } from 'antd';
 import { get } from 'lodash';
 import { getAlertOperation, getAlertsOperation } from '../../epics';
 import styles from './styles.css';
@@ -49,10 +49,10 @@ function AlertDetails(props) {
         {renderDetailItems(detailsKeys)}
       </div>
 
-      <div className={cx('AlertDetailsBack')}>
-        <Button onClick={closeAlertDetails} type="primary">
-          Close
-        </Button>
+      <div className={cx('AlertDetailsBack')} onClick={closeAlertDetails}>
+        <Tooltip placement="topLeft" title={<span>Close</span>}>
+          <Icon type="close-square" />
+        </Tooltip>
       </div>
     </div>
   ) : null;
@@ -80,7 +80,7 @@ AlertDetails.propTypes = {
 
 AlertDetails.defaultProps = {
   selected: null,
-  setActiveItem: () => {},
-  unSelectAlert: () => {},
-  refreshAlerts: () => {},
+  setActiveItem: () => { },
+  unSelectAlert: () => { },
+  refreshAlerts: () => { },
 };

--- a/src/map/components/AlertDetails/index.js
+++ b/src/map/components/AlertDetails/index.js
@@ -3,116 +3,40 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames/bind';
 import { Button } from 'antd';
-import moment from 'moment';
 import { get } from 'lodash';
 import { getAlertOperation, getAlertsOperation } from '../../epics';
 import styles from './styles.css';
 import { alertPropTypes } from '../../../common/lib/propTypesUtil';
+import AlertDetailItem from './components/AlertDetailItem';
 import { setAlertNavActive } from '../../actions';
 
 const cx = classnames.bind(styles);
 
-function AlertDetailsValue({ property, value }) {
-  const formatTitle = title => {
-    switch (title) {
-      case 'area.description': {
-        return ' AREA DESCRIPTION';
-      }
-      case 'description': {
-        return ' ALERT DESCRIPTION';
-      }
-      case 'reportedAt': {
-        return 'WHEN WAS REPORTED';
-      }
-      case 'expectedAt': {
-        return 'WHEN IS EXPECTED';
-      }
-
-      case 'expiredAt': {
-        return 'WHEN WILL EXPIRE';
-      }
-
-      default:
-        return title;
-    }
-  };
-
-  const formatValue = (title, data) => {
-    switch (title) {
-      case 'reportedAt': {
-        const m = moment(data, 'YYYY-MM-DD');
-        return `${m.calendar()}`;
-      }
-      case 'expectedAt': {
-        const m = moment(data, 'YYYY-MM-DD');
-        return `${m.calendar()}`;
-      }
-
-      case 'expiredAt': {
-        const m = moment(data, 'YYYY-MM-DD');
-        return `${m.calendar()}`;
-      }
-
-      default:
-        return data;
-    }
-  };
-
-  return (
-    <div style={{ marginBottom: '20px' }}>
-      <div
-        style={{
-          color: '#189ad1',
-          display: 'table',
-          textTransform: 'uppercase',
-        }}
-      >
-        {' '}
-        {formatTitle(property)}
-      </div>
-      <div
-        style={{
-          fontWeight: 700,
-          fontSize: '13px',
-          color: '#8a8a8a',
-        }}
-      >
-        {' '}
-        {formatValue(property, value)}{' '}
-      </div>
-    </div>
-  );
-}
-
-AlertDetailsValue.propTypes = {
-  property: PropTypes.string,
-  value: PropTypes.string,
-};
-
-AlertDetailsValue.defaultProps = {
-  property: 'no data',
-  value: 'no data',
-};
-
 function AlertDetails(props) {
   const { selected, unSelectAlert, setActiveItem, refreshAlerts } = props;
   const detailsKeys = [
+    'source',
+    'status',
+    'type',
+    'scope',
     'category',
+    'event',
+    'response',
     'urgency',
     'severity',
-    'severity',
     'certainty',
+    'headline',
     'reportedAt',
     'expectedAt',
     'expiredAt',
     'description',
     'area.description',
-    'instruction',
+    'instruction'
   ];
 
   const renderDetailItems = keys =>
     keys.map(key => (
-      <AlertDetailsValue property={key} value={get(selected, key)} />
+      <AlertDetailItem property={key} value={get(selected, key)} />
     ));
   const closeAlertDetails = () => {
     setActiveItem('legend');

--- a/src/map/components/AlertDetails/index.js
+++ b/src/map/components/AlertDetails/index.js
@@ -51,7 +51,7 @@ function AlertDetails(props) {
 
       <div className={cx('AlertDetailsBack')}>
         <Button onClick={closeAlertDetails} type="primary">
-          Back
+          Close
         </Button>
       </div>
     </div>

--- a/src/map/components/AlertDetails/styles.css
+++ b/src/map/components/AlertDetails/styles.css
@@ -1,18 +1,12 @@
 .AlertDetails {
     background-color: white;
     display: flex;  
-    flex-direction: column;
     height: 80vh;
     overflow-y: auto;
 }
 
 .AlertDetailsBack {
   display: flex;
-  justify-content: flex-end;
-  margin: 0 5px 40px 5px;
-  position: fixed;
-  bottom: 11vh;
-  right: 1.5vw;
 
 }
 
@@ -23,7 +17,11 @@
     flex: 1;
 }
 
-.AlertDetailsHeader, .AlertDetailsContent {
+.AlertDetailsHeader, .AlertDetailsContent, .AlertDetailsBack {
     padding: 10px;
+}
+
+.AlertDetails .anticon {
+    font-size: 24px;
 }
 

--- a/src/map/components/AlertDetails/styles.css
+++ b/src/map/components/AlertDetails/styles.css
@@ -10,6 +10,9 @@
   display: flex;
   justify-content: flex-end;
   margin: 0 5px 40px 5px;
+  position: fixed;
+  bottom: 11vh;
+  right: 1.5vw;
 
 }
 


### PR DESCRIPTION
## Description
Added missing Alert detail fields. all CAP fields supplied by API can now be displayed




**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
 - [x] Feature

**Does this PR introduce a breaking change?**
 - [x] No